### PR TITLE
Fix for target files with unicode characters

### DIFF
--- a/src/lpad_template.erl
+++ b/src/lpad_template.erl
@@ -72,10 +72,10 @@ handle_write_file({error, Err}, File) ->
 
 resolve_refs(Str, Vars) ->
     Compiled = compile_str(Str),
-    iolist_to_list(render(Compiled, Vars)).
+    unicode:characters_to_binary(render(Compiled, Vars)).
 
 compile_str(Str) ->
-    Template = iolist_to_binary(Str),
+    Template = unicode:characters_to_binary(Str),
     Mod = str_module(Str),
     handle_compile(erlydtl:compile(Template, Mod), Mod, Str).
 


### PR DESCRIPTION
When target file names for templates contains Unicode characters higher than 255, exported files names get broken.

From http://www.erlang.org/doc/apps/stdlib/unicode_usage.html , it seems that `iolist_to_list` can safely be replaced by `unicode:characters_to_binary` when dealing with unicode strings.
