### PR TITLE
Fix for unicode strings in template map dynamic name

### DIFF
--- a/src/lpad_template.erl
+++ b/src/lpad_template.erl
@@ -71,8 +71,8 @@ handle_write_file({error, Err}, File) ->
 %%%===================================================================
 
 resolve_refs(Str, Vars) ->
-    Compiled = compile_str(Str),
-    unicode:characters_to_binary(render(Compiled, Vars)).
+    Compiled = compile_str( unicode:characters_to_binary(Str) ),
+    iolist_to_binary(render(Compiled, Vars)).
 
 compile_str(Str) ->
     Template = unicode:characters_to_binary(Str),


### PR DESCRIPTION
Fix for unicode strings with the dynamic part of template names.

For example, the following rule will export the file with a garbled name if the name contains Unicode strings.

```
"dist/blog/tags/{{tag.name}}.html" => {template_map, "src/templates/tag.html", {tag, PostsTagList}},
```

Sorry for missing it in the previous pull request. 
