### PR TITLE
Fix typo in documentation

### DIFF
--- a/docs/articles/getting-started.md
+++ b/docs/articles/getting-started.md
@@ -266,7 +266,7 @@ You can copy files matching a pattern to the site using `{files, Pattern}`.
 For example:
 
 ```erlang
-site(_) -> #{ "site/css/*.css" => {file, "assets/*.css"} }.
+site(_) -> #{ "site/css/*.css" => {files, "assets/*.css"} }.
 ```
 
 ## {string, String}


### PR DESCRIPTION
Changed to documentation to use the `files` atom instead of `file` in the example for `{files, Pattern}`
