### PR TITLE
Use `realpath` for Mac OS X compatibility

### DIFF
--- a/bin/lpad-gen
+++ b/bin/lpad-gen
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-BIN_DIR="$(cd "$(dirname $(readlink -f "${BASH_SOURCE[0]}"))" && pwd)"
+BIN_DIR="$(cd "$(dirname $(realpath "${BASH_SOURCE[0]}"))" && pwd)"
 LPAD_HOME="$(dirname $BIN_DIR)"
 ESCRIPT=/tmp/__lpad-gen.escript
 


### PR DESCRIPTION
`readlink` work different way on OS X  (like lots of other utils...)
`realpath` could be used instead, but it's not installed by default anywhere.